### PR TITLE
商品一覧表示

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,7 @@
       <li class='list'>
         <%= link_to item_path(item.id),class:'list', method: :get do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: 'item-img' %>
         <% end %>
 
           <%# 商品が売れていればsold outの表示 %>
@@ -143,10 +143,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -159,6 +159,7 @@
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items.length == 0%>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -175,6 +176,7 @@
           </div>
         </div>
       </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合のダミー %>
     </ul>


### PR DESCRIPTION
#What
フリマアプリにおける商品一覧表示機能の実装

 #Why
フリマアプリのトップページに商品一覧を表示させるため

#動作確認
https://gyazo.com/391d9900420b32ed38e1bdb3c1c83b9f

"sold out"の表示は商品購入機能実装時に変更いたします。